### PR TITLE
Add animated gradient background

### DIFF
--- a/gui/electron/index.html
+++ b/gui/electron/index.html
@@ -5,7 +5,26 @@
     <title>NeuroShell</title>
     <link rel="stylesheet" href="node_modules/xterm/css/xterm.css" />
     <style>
-      html, body, #root { height: 100%; margin: 0; background: black; overflow: hidden; }
+      html, body {
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+      }
+
+      #root {
+        height: 100%;
+        background: linear-gradient(120deg, #a1c4fd, #c2e9fb, #a1c4fd);
+        background-size: 400% 400%;
+        animation: cloudAnimation 60s ease-in-out infinite;
+        border-radius: 20px;
+        overflow: hidden;
+      }
+
+      @keyframes cloudAnimation {
+        0% { background-position: 0% 50%; }
+        50% { background-position: 100% 50%; }
+        100% { background-position: 0% 50%; }
+      }
     </style>
   </head>
   <body>

--- a/gui/electron/index.html
+++ b/gui/electron/index.html
@@ -26,6 +26,30 @@
         background-color: transparent !important;
       }
 
+      /* Minimal scrollbar styling - hidden until scrolling */
+      .xterm-viewport::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      .xterm-viewport::-webkit-scrollbar-track {
+        background: transparent;
+      }
+
+      .xterm-viewport::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0);
+        border-radius: 4px;
+        transition: background 0.2s ease-in-out;
+      }
+
+      .xterm-viewport.scrolling::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.4);
+      }
+
+      .xterm-viewport {
+        scrollbar-width: thin;
+        scrollbar-color: rgba(255, 255, 255, 0.4) transparent;
+      }
+
       @keyframes cloudAnimation {
         0% { background-position: 0% 50%; }
         50% { background-position: 100% 50%; }

--- a/gui/electron/index.html
+++ b/gui/electron/index.html
@@ -13,11 +13,17 @@
 
       #root {
         height: 100%;
+        box-sizing: border-box;
+        padding: 10px;
         background: linear-gradient(120deg, #a1c4fd, #c2e9fb, #a1c4fd);
         background-size: 400% 400%;
         animation: cloudAnimation 60s ease-in-out infinite;
         border-radius: 20px;
         overflow: hidden;
+      }
+
+      .xterm, .xterm-viewport, .xterm-screen {
+        background-color: transparent !important;
       }
 
       @keyframes cloudAnimation {

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -12,6 +12,8 @@ function createWindow() {
     frame: false,
     fullscreen: false,
     autoHideMenuBar: true,
+    transparent: true,
+    backgroundColor: '#00000000',
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false

--- a/gui/electron/renderer.js
+++ b/gui/electron/renderer.js
@@ -8,7 +8,9 @@ function TerminalApp() {
   const containerRef = React.useRef(null);
 
   React.useEffect(() => {
-    const term = new Terminal();
+    const term = new Terminal({
+      theme: { background: 'transparent' }
+    });
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(containerRef.current);

--- a/gui/electron/renderer.js
+++ b/gui/electron/renderer.js
@@ -8,9 +8,30 @@ function TerminalApp() {
   const containerRef = React.useRef(null);
 
   React.useEffect(() => {
-    const term = new Terminal({
-      theme: { background: 'transparent' }
-    });
+    const theme = {
+      background: 'transparent',
+      foreground: '#222222',
+      cursor: '#222222',
+      selection: 'rgba(0,0,0,0.25)',
+      black: '#0a0a0a',
+      red: '#c94f6d',
+      green: '#50a14f',
+      yellow: '#c18401',
+      blue: '#4078f2',
+      magenta: '#a626a4',
+      cyan: '#0184bc',
+      white: '#c0c0c0',
+      brightBlack: '#808080',
+      brightRed: '#ec6a88',
+      brightGreen: '#8dc891',
+      brightYellow: '#f6c177',
+      brightBlue: '#73baf9',
+      brightMagenta: '#d670d6',
+      brightCyan: '#5dbbc1',
+      brightWhite: '#ffffff'
+    };
+
+    const term = new Terminal({ theme });
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(containerRef.current);

--- a/gui/electron/renderer.js
+++ b/gui/electron/renderer.js
@@ -15,6 +15,16 @@ function TerminalApp() {
     term.loadAddon(fitAddon);
     term.open(containerRef.current);
     fitAddon.fit();
+
+    const viewport = containerRef.current.querySelector('.xterm-viewport');
+    if (viewport) {
+      let scrollTimeout;
+      viewport.addEventListener('scroll', () => {
+        viewport.classList.add('scrolling');
+        clearTimeout(scrollTimeout);
+        scrollTimeout = setTimeout(() => viewport.classList.remove('scrolling'), 800);
+      });
+    }
     term.focus();
     term.onData(data => ipcRenderer.send('terminal-data', data));
     ipcRenderer.on('shell-data', (_, d) => term.write(d));


### PR DESCRIPTION
## Summary
- smooth window corners with `transparent` Electron window
- animate gradient background for a slow cloud-like effect

## Testing
- `npm install`
- `npm start` *(fails: running as root without --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_686159ce8fc483269f3e6b1c65071323