### PR TITLE
Fix terminal resize handling in GUI

### DIFF
--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -25,12 +25,13 @@ function createWindow() {
 
 app.whenReady().then(createWindow);
 
-ipcMain.on('start-shell', (event) => {
+ipcMain.on('start-shell', (event, size = {}) => {
   const shell = os.platform() === 'win32' ? 'powershell.exe' : process.env.SHELL || 'bash';
+  const { cols = 80, rows = 24 } = size;
   ptyProcess = pty.spawn(shell, [], {
     name: 'xterm-color',
-    cols: 80,
-    rows: 24,
+    cols,
+    rows,
     cwd: process.env.HOME,
     env: process.env
   });
@@ -45,4 +46,10 @@ ipcMain.on('start-shell', (event) => {
 
 ipcMain.on('terminal-data', (_, data) => {
   ptyProcess && ptyProcess.write(data);
+});
+
+ipcMain.on('resize', (_, size) => {
+  if (ptyProcess && size) {
+    ptyProcess.resize(size.cols, size.rows);
+  }
 });

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -9,6 +9,8 @@ function createWindow() {
   win = new BrowserWindow({
     width: 800,
     height: 600,
+    minWidth: 100,
+    minHeight: 100,
     frame: false,
     fullscreen: false,
     autoHideMenuBar: true,

--- a/gui/electron/renderer.js
+++ b/gui/electron/renderer.js
@@ -35,7 +35,11 @@ function TerminalApp() {
     const fitAddon = new FitAddon();
     term.loadAddon(fitAddon);
     term.open(containerRef.current);
-    fitAddon.fit();
+    const fitAndResize = () => {
+      fitAddon.fit();
+      ipcRenderer.send('resize', { cols: term.cols, rows: term.rows });
+    };
+    fitAndResize();
 
     const viewport = containerRef.current.querySelector('.xterm-viewport');
     if (viewport) {
@@ -49,8 +53,8 @@ function TerminalApp() {
     term.focus();
     term.onData(data => ipcRenderer.send('terminal-data', data));
     ipcRenderer.on('shell-data', (_, d) => term.write(d));
-    ipcRenderer.send('start-shell');
-    window.addEventListener('resize', () => fitAddon.fit());
+    ipcRenderer.send('start-shell', { cols: term.cols, rows: term.rows });
+    window.addEventListener('resize', fitAndResize);
   }, []);
 
   return React.createElement('div', { ref: containerRef, style: { height: '100%', width: '100%' } });


### PR DESCRIPTION
## Summary
- ensure `node-pty` spawn uses provided cols and rows
- resize pty when terminal window changes
- notify main process of terminal size in renderer

## Testing
- `npm install`
- `npm start` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68616175c6c4832684d4246f54b30baa