### PR TITLE
Add initial agent scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 gui/electron/node_modules/
 gui/electron/package-lock.json
+
+# Python artifacts
+__pycache__/

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -1,0 +1,1 @@
+"""NeuroShell agent package."""

--- a/agent/executor.py
+++ b/agent/executor.py
@@ -1,0 +1,11 @@
+"""Executor for the NeuroShell agent."""
+from typing import List
+
+
+def execute_steps(steps: List[str]) -> None:
+    """Execute a list of plain-text steps.
+
+    Currently this function simply prints each step to the console.
+    """
+    for step in steps:
+        print(step)

--- a/agent/memory.py
+++ b/agent/memory.py
@@ -1,0 +1,17 @@
+"""Simple in-memory log for the NeuroShell agent."""
+from typing import List
+
+
+class Memory:
+    """Stores past interactions in memory."""
+
+    def __init__(self) -> None:
+        self.logs: List[str] = []
+
+    def add(self, entry: str) -> None:
+        """Add a log entry."""
+        self.logs.append(entry)
+
+    def get(self) -> List[str]:
+        """Return all log entries."""
+        return self.logs

--- a/agent/parser.py
+++ b/agent/parser.py
@@ -1,0 +1,45 @@
+"""Intent parser for NeuroShell agent."""
+import json
+import os
+from typing import Any, Dict
+
+import openai
+
+
+def parse_intent(text: str) -> Dict[str, Any]:
+    """Parse natural language instructions into a structured intent dictionary.
+
+    Parameters
+    ----------
+    text: str
+        Natural language user input describing the desired action.
+
+    Returns
+    -------
+    dict
+        Parsed intent as a dictionary. On failure, returns a dictionary with an
+        ``error`` key describing the issue.
+    """
+    openai.api_key = os.getenv("OPENAI_API_KEY")
+    if openai.api_key is None:
+        return {"error": "OPENAI_API_KEY environment variable not set"}
+
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are an intent parser for a shell-based AI assistant. "
+                "Given a user instruction, respond ONLY with a JSON object "
+                "describing the intent. The JSON should be short and use \"action\" "
+                "and other relevant fields."
+            ),
+        },
+        {"role": "user", "content": text},
+    ]
+
+    try:
+        response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+        content = response.choices[0].message["content"].strip()
+        return json.loads(content)
+    except Exception as exc:  # broad catch to avoid raising inside shell
+        return {"error": str(exc)}

--- a/agent/planner.py
+++ b/agent/planner.py
@@ -1,0 +1,12 @@
+"""Simple planning module for the NeuroShell agent."""
+from typing import Any, Dict, List
+
+
+def plan_steps(intent: Dict[str, Any]) -> List[str]:
+    """Convert a parsed intent into executable steps.
+
+    This is a placeholder implementation that simply describes the intent.
+    """
+    action = intent.get("action", "do_something")
+    description = intent.get("description", "")
+    return [f"Action: {action}", f"Description: {description}"]

--- a/agent/tools/shell.py
+++ b/agent/tools/shell.py
@@ -1,0 +1,9 @@
+"""Shell tool used by the NeuroShell agent."""
+import subprocess
+from typing import List
+
+
+def run_command(cmd: List[str]) -> str:
+    """Run a shell command and return its output."""
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return result.stdout


### PR DESCRIPTION
## Summary
- set up `agent` package with planner, executor, memory and shell tool
- implement `parse_intent` that calls OpenAI API for structured intents
- ignore Python caches

## Testing
- `python -m compileall agent`


------
https://chatgpt.com/codex/tasks/task_e_68628e64bc048326a1fc6e1be865bd1d